### PR TITLE
FAQ should link contributing.md on master

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -41,12 +41,12 @@
     </h2>
     <p>
       Everyone can help.
-      io.js adheres to a <a href="https://github.com/iojs/io.js/blob/master/CONTRIBUTING.md#code-of-conduct">code of conduct</a>, and contributions, releases, and contributorship are under an <a href="https://github.com/iojs/io.js/blob/v0.12/CONTRIBUTING.md#governance">open governance</a> model.
+      io.js adheres to a <a href="https://github.com/iojs/io.js/blob/master/CONTRIBUTING.md#code-of-conduct">code of conduct</a>, and contributions, releases, and contributorship are under an <a href="https://github.com/iojs/io.js/blob/master/CONTRIBUTING.md#governance">open governance</a> model.
     </p>
     <p>
       To get started, there are open <a href="https://github.com/iojs/io.js/issues"> discussions on github</a>, and we'd love to hear your feedback.
-      Becoming involved in discussions is a good way to get a feel of where you can help out further. If there is
-      something there you feel you can tackle, please <a href="https://github.com/iojs/io.js/blob/v0.12/CONTRIBUTING.md#code-contributions">make a pull request</a>.
+      Becoming invloved in discussions is a good way to get a feel of where you can help out further. If there is
+      something there you feel you can tackle, please <a href="https://github.com/iojs/io.js/blob/master/CONTRIBUTING.md#code-contributions">make a pull request</a>.
 
 
       In addition, using <a href="http://nodebug.me">Nodebug.me</a> is a good way to help Triage the issues in the backlog.
@@ -75,7 +75,7 @@
    --><a href="https://github.com/iojs">Github Org</a><!--
    --><a href="http://webchat.freenode.net/?channels=io.js">IRC Chat</a><!--
    --><a href="http://logs.libuv.org/io.js/latest">Logs</a><!--
-   --><a href="https://github.com/iojs/io.js/blob/v0.12/CONTRIBUTING.md#governance">Governance</a>
+   --><a href="https://github.com/iojs/io.js/blob/master/CONTRIBUTING.md#governance">Governance</a>
     </nav>
   </footer>
 


### PR DESCRIPTION
Currently: 

* 1/4 links point to contributing.md on `master` branch
* 3/4 links point to contributing.md on `v0.12` branch

This PR updates all to `master`.